### PR TITLE
feat: extend ui.form.requestSubmit with intent (save-draft / finalize)

### DIFF
--- a/form-filler-swing/src/main/java/health/tiro/formfiller/swing/FormFiller.java
+++ b/form-filler-swing/src/main/java/health/tiro/formfiller/swing/FormFiller.java
@@ -186,11 +186,22 @@ public class FormFiller<H extends AbstractSmartMessageHandler> implements AutoCl
     }
 
     /**
-     * Request form submission from the frontend.
+     * Request form submission from the frontend (finalize).
      */
     public void requestSubmit() {
-        logger.info("Requesting form submit");
-        handler.sendFormRequestSubmitAsync(null);
+        requestSubmit(null);
+    }
+
+    /**
+     * Request form submission from the frontend with an explicit intent.
+     *
+     * @param intent {@code "finalize"} (or {@code null}) finalizes the form;
+     *               {@code "save-draft"} persists an in-progress draft. The form
+     *               component remains the authority on the resulting status.
+     */
+    public void requestSubmit(String intent) {
+        logger.info("Requesting form submit (intent={})", intent);
+        handler.sendFormRequestSubmitAsync(intent, null);
     }
 
     /**

--- a/form-filler-swing/src/main/resources/health/tiro/formfiller/swing/tiro-swm-bridge.js
+++ b/form-filler-swing/src/main/resources/health/tiro/formfiller/swing/tiro-swm-bridge.js
@@ -139,7 +139,16 @@
 
       case "ui.form.requestSubmit":
         if (formFiller && formFiller.questionnaire) {
-          formFiller.submit();
+          // Map the host intent ("finalize" | "save-draft") to the form-filler's
+          // target status. The form still owns the completed -> amended promotion
+          // (via originate provenance) and the required-field validation skip for
+          // in-progress drafts.
+          var intent = message.payload && message.payload.intent;
+          if (intent === "save-draft") {
+            formFiller.submit({ status: "in-progress" });
+          } else {
+            formFiller.submit();
+          }
         }
         break;
 
@@ -338,12 +347,7 @@
   // Init
   // ===========================================
 
-  var latestResponse = null;
-
   function wireFormFiller(formFiller) {
-    formFiller.addEventListener("tiro-update", function (event) {
-      latestResponse = event.detail.response;
-    });
     formFiller.addEventListener("tiro-submit", function (event) {
       submitForm(formFiller, event.detail.response);
     });
@@ -386,10 +390,11 @@
     init: init,
     saveProgress: function () {
       var formFiller = document.querySelector(FORM_FILLER_SELECTOR);
-      if (latestResponse && formFiller) {
-        var response = JSON.parse(JSON.stringify(latestResponse));
-        response.status = "in-progress";
-        submitForm(formFiller, response);
+      if (formFiller && formFiller.questionnaire) {
+        // Route through the form's real submit pipeline (required-field validation
+        // skip, provenance) instead of stamping response.status externally. The form
+        // emits tiro-submit with status "in-progress", which submitForm forwards.
+        formFiller.submit({ status: "in-progress" });
       }
     },
     validate: function () {

--- a/smart-web-messaging-core/src/main/java/health/tiro/swm/AbstractSmartMessageHandler.java
+++ b/smart-web-messaging-core/src/main/java/health/tiro/swm/AbstractSmartMessageHandler.java
@@ -434,10 +434,23 @@ public abstract class AbstractSmartMessageHandler {
     // ========== Non-typed outbound convenience methods ==========
 
     public CompletableFuture<String> sendFormRequestSubmitAsync(Consumer<SmartMessageResponse> responseHandler) {
-        logger.debug("Sending ui.form.requestSubmit message.");
-        return sendMessageAsync("ui.form.requestSubmit", new RequestPayload(), responseHandler);
+        return sendFormRequestSubmitAsync(null, responseHandler);
     }
 
+    public CompletableFuture<String> sendFormRequestSubmitAsync(String intent, Consumer<SmartMessageResponse> responseHandler) {
+        logger.debug("Sending ui.form.requestSubmit message. intent={}", intent);
+        // null intent keeps the backward-compatible empty payload, so the form defaults
+        // to "finalize". Only carry a FormRequestSubmit when the host expresses an intent.
+        RequestPayload payload = intent == null ? new RequestPayload() : new FormRequestSubmit(intent);
+        return sendMessageAsync("ui.form.requestSubmit", payload, responseHandler);
+    }
+
+    /**
+     * @deprecated ui.form.persist is a no-op in every bridge. Use
+     * {@link #sendFormRequestSubmitAsync(String, Consumer)} with {@code intent = "save-draft"}
+     * to persist a draft through the form's submit pipeline.
+     */
+    @Deprecated
     public CompletableFuture<String> sendFormPersistAsync(Consumer<SmartMessageResponse> responseHandler) {
         logger.debug("Sending ui.form.persist message.");
         return sendMessageAsync("ui.form.persist", new RequestPayload(), responseHandler);

--- a/smart-web-messaging-core/src/main/java/health/tiro/swm/message/payload/FormRequestSubmit.java
+++ b/smart-web-messaging-core/src/main/java/health/tiro/swm/message/payload/FormRequestSubmit.java
@@ -1,0 +1,40 @@
+package health.tiro.swm.message.payload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Payload for {@code ui.form.requestSubmit} when the host wants to express which
+ * user-facing action triggered the submit. The form component remains the authority
+ * on the resulting {@code QuestionnaireResponse.status} (it derives {@code amended}
+ * from originate provenance and skips required-field validation for drafts) — the
+ * host only states the intent.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FormRequestSubmit extends RequestPayload {
+
+    /**
+     * "finalize" (default) — validate and write {@code status = "completed"}
+     * (or "amended" when prior originate provenance exists).
+     * "save-draft" — skip required-field validation and write {@code status = "in-progress"}.
+     * A missing value is treated as "finalize" by the form.
+     */
+    @JsonProperty("intent")
+    private String intent;
+
+    public FormRequestSubmit() {
+        super();
+    }
+
+    public FormRequestSubmit(String intent) {
+        this.intent = intent;
+    }
+
+    public String getIntent() {
+        return intent;
+    }
+
+    public void setIntent(String intent) {
+        this.intent = intent;
+    }
+}

--- a/smart-web-messaging-r4/src/test/java/health/tiro/swm/r4/SmartMessageHandlerTest.java
+++ b/smart-web-messaging-r4/src/test/java/health/tiro/swm/r4/SmartMessageHandlerTest.java
@@ -613,4 +613,37 @@ class SmartMessageHandlerTest {
         assertEquals("patient", launchContext.get(0).get("name").asText());
     }
 
+    // ========== sendFormRequestSubmitAsync tests ==========
+
+    @Test
+    void sendFormRequestSubmitAsync_defaultIntent_omitsIntentField() throws Exception {
+        AtomicReference<String> sentMessage = new AtomicReference<>();
+        handler.setMessageSender(msg -> {
+            sentMessage.set(msg);
+            return CompletableFuture.completedFuture("OK");
+        });
+
+        handler.sendFormRequestSubmitAsync(null);
+
+        JsonNode messageNode = objectMapper.readTree(sentMessage.get());
+        assertEquals("ui.form.requestSubmit", messageNode.get("messageType").asText());
+        // Backward-compatible: no intent expressed -> empty payload, no "intent" field.
+        assertFalse(messageNode.get("payload").has("intent"));
+    }
+
+    @Test
+    void sendFormRequestSubmitAsync_saveDraftIntent() throws Exception {
+        AtomicReference<String> sentMessage = new AtomicReference<>();
+        handler.setMessageSender(msg -> {
+            sentMessage.set(msg);
+            return CompletableFuture.completedFuture("OK");
+        });
+
+        handler.sendFormRequestSubmitAsync("save-draft", null);
+
+        JsonNode messageNode = objectMapper.readTree(sentMessage.get());
+        assertEquals("ui.form.requestSubmit", messageNode.get("messageType").asText());
+        assertEquals("save-draft", messageNode.get("payload").get("intent").asText());
+    }
+
 }

--- a/smart-web-messaging-r5/src/test/java/health/tiro/swm/r5/SmartMessageHandlerTest.java
+++ b/smart-web-messaging-r5/src/test/java/health/tiro/swm/r5/SmartMessageHandlerTest.java
@@ -613,4 +613,37 @@ class SmartMessageHandlerTest {
         assertEquals("patient", launchContext.get(0).get("name").asText());
     }
 
+    // ========== sendFormRequestSubmitAsync tests ==========
+
+    @Test
+    void sendFormRequestSubmitAsync_defaultIntent_omitsIntentField() throws Exception {
+        AtomicReference<String> sentMessage = new AtomicReference<>();
+        handler.setMessageSender(msg -> {
+            sentMessage.set(msg);
+            return CompletableFuture.completedFuture("OK");
+        });
+
+        handler.sendFormRequestSubmitAsync(null);
+
+        JsonNode messageNode = objectMapper.readTree(sentMessage.get());
+        assertEquals("ui.form.requestSubmit", messageNode.get("messageType").asText());
+        // Backward-compatible: no intent expressed -> empty payload, no "intent" field.
+        assertFalse(messageNode.get("payload").has("intent"));
+    }
+
+    @Test
+    void sendFormRequestSubmitAsync_saveDraftIntent() throws Exception {
+        AtomicReference<String> sentMessage = new AtomicReference<>();
+        handler.setMessageSender(msg -> {
+            sentMessage.set(msg);
+            return CompletableFuture.completedFuture("OK");
+        });
+
+        handler.sendFormRequestSubmitAsync("save-draft", null);
+
+        JsonNode messageNode = objectMapper.readTree(sentMessage.get());
+        assertEquals("ui.form.requestSubmit", messageNode.get("messageType").asText());
+        assertEquals("save-draft", messageNode.get("payload").get("intent").asText());
+    }
+
 }


### PR DESCRIPTION
Closes #14. Sibling of Tiro-health/net-integration-harness#19 (PR Tiro-health/net-integration-harness#25).

## Summary

Extends `ui.form.requestSubmit` with an optional `intent` (`"finalize"` | `"save-draft"`) so the host can express which user-facing action it triggered, while the form component remains the authority on the resulting `QuestionnaireResponse.status`. This replaces the out-of-protocol `window.SmartWebMessaging.saveProgress()` workaround that stamped `response.status = "in-progress"` externally and bypassed the form's submit pipeline (validation skip, provenance, amended-promotion).

## Changes

- **`FormRequestSubmit` payload** — new `RequestPayload` subclass carrying `intent`.
- **`AbstractSmartMessageHandler.sendFormRequestSubmitAsync`** — added a `(String intent, Consumer)` overload; the existing overload delegates with `null` (empty payload → form defaults to finalize, backward-compatible).
- **`FormFiller.requestSubmit(String intent)`** overload; the no-arg version finalizes.
- **Bridge** — maps host intent to the form-filler's **target status**. The landed atticus-frontend API is `submit({ status: "in-progress" | "completed" })`, *not* `submit({ intent })`, so: `save-draft → submit({ status: "in-progress" })`, finalize/absent → `submit()` (defaults to completed). The form still owns the completed → amended promotion and the draft validation skip.
- **`saveProgress()` reimplemented** on top of `submit({ status: "in-progress" })` so drafts go through the form's real submit pipeline; removed the now-dead `latestResponse` tracking.
- **Deprecated `sendFormPersistAsync`** (`@Deprecated`; `ui.form.persist` is a no-op bridge-side).
- **Tests** — R4 and R5 `SmartMessageHandlerTest`: a `save-draft` payload case + a backward-compatible default asserting no `intent` field.

## Verification

- `mvn test` on `smart-web-messaging-core/-r4/-r5`: **23/23 pass** in each of R4 and R5 (includes the 2 new cases each).
- `form-filler-swing` compiles clean.

## Cross-repo

- .NET sibling: Tiro-health/net-integration-harness#19 / #25
- Frontend dependency (landed): Tiro-health/atticus-frontend#2203

🤖 Generated with [Claude Code](https://claude.com/claude-code)