### PR TITLE
feat: typed SDC client for $validate / $extract (R5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ handler.sendSdcConfigureContextAsync(
 | Swing | `form-filler-swing` | `FormFiller` controller + `EmbeddedBrowser` interface. Depends on core. |
 | Swing JxBrowser | `form-filler-swing-jxbrowser` | JxBrowser adapter. Depends on swing + JxBrowser (provided). |
 | Swing Equo | `form-filler-swing-equo` | Equo Chromium adapter. Depends on swing + Equo Chromium (provided). |
+| SDC Client Core | `sdc-client-core` | FHIR-version-agnostic core for the stateless SDC server operations. Depends on `hapi-fhir-base` + Apache HttpClient. |
+| SDC Client R5 | `sdc-client-r5` | FHIR R5 binding: `SdcClient` for `$validate`/`$extract`. Depends on core + `hapi-fhir-structures-r5`. |
+
+## SDC Client
+
+`SdcClient` (module `sdc-client-r5`) is a thin, strongly-typed client over the **stateless SDC server** FHIR operations — call them directly instead of hand-building request bodies and parsing raw responses. Separate from the messaging/viewer modules (an HTTP/FHIR client, not the embedded-UI bridge).
+
+```java
+import health.tiro.sdc.client.r5.SdcClient;
+import org.hl7.fhir.r5.model.*;
+
+try (SdcClient sdc = new SdcClient("https://host/fhir/r5")) {   // optionally pass a CloseableHttpClient for TLS/proxy
+    OperationOutcome outcome = sdc.validate(questionnaireResponse);   // POST QuestionnaireResponse/$validate
+    Bundle extracted        = sdc.extract(questionnaireResponse);     // POST QuestionnaireResponse/$extract
+}
+```
+
+- **R5-only**: these SDC operations exist only on `/fhir/r5` (a future R4 server would be one new `sdc-client-r4` binding). **No auth** — the base URL is sufficient. Calls are **blocking** (HAPI/Apache HttpClient are synchronous).
+- A validation *failure* comes back as `OperationOutcome` issues; transport/server errors (non-2xx) throw `SdcOperationException` (carrying the status + any server outcome). Responses are parsed leniently, tolerating elements/codes a newer server emits.
+- **Use one SDC base for both**: `baseUrl` here and the viewer's `FormFillerConfig.sdcEndpointAddress` are the same concept — the SDC server. A host that embeds the form **and** calls the client should configure the address once and pass it to both. The client has no default base (you must pass one) to avoid silently diverging from a configured viewer.
+- `$extract` returns a transaction `Bundle`: the resources the answers produce (Tiro's template questionnaires yield a `Composition` with per-section narrative; definition-based ones yield structured resources), plus the source QR and a `Provenance`. `$populate` is tracked separately (#20).
 
 ## Message Types Supported
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
         <module>form-filler-swing</module>
         <module>form-filler-swing-jxbrowser</module>
         <module>form-filler-swing-equo</module>
+        <module>sdc-client-core</module>
+        <module>sdc-client-r5</module>
     </modules>
 
     <properties>
@@ -82,6 +84,17 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>health.tiro</groupId>
+                <artifactId>sdc-client-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>health.tiro</groupId>
+                <artifactId>sdc-client-r5</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- HAPI FHIR -->
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
@@ -105,6 +118,11 @@
             </dependency>
 
             <!-- Jackson -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
@@ -164,6 +182,13 @@
                 <groupId>com.equo</groupId>
                 <artifactId>com.equo.chromium</artifactId>
                 <version>${equo.chromium.version}</version>
+            </dependency>
+
+            <!-- HTTP client for the SDC client's bare-resource POSTs (Java 8 compatible) -->
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.14</version>
             </dependency>
 
             <!-- Testing -->

--- a/sdc-client-core/pom.xml
+++ b/sdc-client-core/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>health.tiro</groupId>
+        <artifactId>smart-web-messaging-parent</artifactId>
+        <version>2.0.0</version>
+    </parent>
+
+    <artifactId>sdc-client-core</artifactId>
+    <packaging>jar</packaging>
+
+    <name>SDC Client Core</name>
+    <description>FHIR-version-agnostic core for the stateless SDC server operations ($validate, $extract). Use a closed-binding module (e.g. sdc-client-r5).</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcClientBase.java
+++ b/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcClientBase.java
@@ -1,0 +1,178 @@
+package health.tiro.sdc.client;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.parser.LenientErrorHandler;
+
+/**
+ * FHIR-version-agnostic client for the stateless SDC server operations. A closed-binding subclass
+ * (e.g. the R5 binding) fixes the FHIR resource types and supplies a lenient {@link IParser}; all
+ * transport/serialization logic lives here.
+ *
+ * <p>Thin over a HAPI {@link IParser} plus an Apache {@link CloseableHttpClient}. The operations POST
+ * a <b>bare</b> {@code QuestionnaireResponse} body (what the SDC server expects), not a
+ * {@code Parameters} envelope, so HAPI's {@code client.operation()/validate()} helpers (which wrap in
+ * {@code Parameters}) are deliberately not used.
+ *
+ * <p>Blocking: HAPI and Apache HttpClient are synchronous.
+ *
+ * @param <TQuestionnaireResponse> the FHIR QuestionnaireResponse type for the bound version
+ * @param <TOperationOutcome> the FHIR OperationOutcome type for the bound version
+ * @param <TBundle> the FHIR Bundle type for the bound version
+ */
+public abstract class SdcClientBase<
+        TQuestionnaireResponse extends IBaseResource,
+        TOperationOutcome extends IBaseOperationOutcome,
+        TBundle extends IBaseBundle>
+        implements Closeable {
+
+    private static final String FHIR_JSON = "application/fhir+json";
+
+    private final String baseUrl;
+    private final FhirContext fhirContext;
+    private final Class<TOperationOutcome> outcomeType;
+    private final Class<TBundle> bundleType;
+    private final CloseableHttpClient httpClient;
+    private final boolean ownsClient;
+
+    /**
+     * @param baseUrl the SDC server FHIR base, e.g. {@code https://host/fhir/r5}. Must be a plain
+     *                path URL with no query/fragment (they can't survive relative resolution).
+     * @param fhirContext the FHIR context for the bound version; a fresh, lenient parser is built
+     *               from it per request (thread-safe — parsers aren't, and leniency is applied on the
+     *               parser so the possibly-shared/cached context is never mutated).
+     * @param httpClient optional pre-configured client (TLS/proxy); when {@code null}, an
+     *                   internally-owned client is created and closed with this instance.
+     */
+    protected SdcClientBase(String baseUrl, FhirContext fhirContext, Class<TOperationOutcome> outcomeType,
+                            Class<TBundle> bundleType, CloseableHttpClient httpClient) {
+        if (baseUrl == null) throw new IllegalArgumentException("baseUrl is required");
+        this.fhirContext = Objects.requireNonNull(fhirContext, "fhirContext");
+        this.outcomeType = Objects.requireNonNull(outcomeType, "outcomeType");
+        this.bundleType = Objects.requireNonNull(bundleType, "bundleType");
+
+        final URI uri;
+        try {
+            uri = new URI(baseUrl);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("baseUrl is not a valid URI: " + baseUrl, e);
+        }
+        // A query/fragment can't survive relative-URI resolution, so it would be silently lost —
+        // fail fast. FHIR bases are plain path URLs.
+        if (uri.getRawQuery() != null || uri.getRawFragment() != null) {
+            throw new IllegalArgumentException(
+                    "baseUrl must be a plain path URL with no query or fragment (e.g. https://host/fhir/r5).");
+        }
+        // Trailing slash so relative operation paths append to the full base.
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+
+        if (httpClient == null) {
+            this.httpClient = HttpClients.createDefault();
+            this.ownsClient = true;
+        } else {
+            this.httpClient = httpClient;
+            this.ownsClient = false;
+        }
+    }
+
+    /**
+     * Validate a QuestionnaireResponse against its referenced Questionnaire
+     * ({@code POST QuestionnaireResponse/$validate}). A validation failure is reported as issues in
+     * the returned outcome, not as an exception.
+     */
+    public TOperationOutcome validate(TQuestionnaireResponse questionnaireResponse) {
+        return post("QuestionnaireResponse/$validate", questionnaireResponse, outcomeType);
+    }
+
+    /**
+     * Extract FHIR resources from a QuestionnaireResponse
+     * ({@code POST QuestionnaireResponse/$extract}), returning the resulting transaction Bundle.
+     */
+    public TBundle extract(TQuestionnaireResponse questionnaireResponse) {
+        return post("QuestionnaireResponse/$extract", questionnaireResponse, bundleType);
+    }
+
+    private <T extends IBaseResource> T post(String relativePath, IBaseResource body, Class<T> returnType) {
+        if (body == null) throw new IllegalArgumentException("resource body is required");
+
+        // Build a parser per call — FhirContext is thread-safe and parser creation is cheap, parsers aren't.
+        // Lenient on the parser instance (not the shared context) so a newer server's unrecognized
+        // elements/codes are tolerated without mutating a cached FhirContext other code shares.
+        final IParser parser = fhirContext.newJsonParser()
+                .setParserErrorHandler(new LenientErrorHandler().setErrorOnInvalidValue(false));
+        final String json = parser.encodeResourceToString(body);
+        final HttpPost request = new HttpPost(baseUrl + relativePath);
+        request.setEntity(new StringEntity(json, ContentType.create(FHIR_JSON, StandardCharsets.UTF_8)));
+        request.setHeader("Accept", FHIR_JSON);
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            final int status = response.getStatusLine().getStatusCode();
+            final HttpEntity entity = response.getEntity();
+            final String responseBody = entity == null ? "" : EntityUtils.toString(entity, StandardCharsets.UTF_8);
+
+            if (status < 200 || status >= 300) {
+                // Best-effort: surface a server OperationOutcome if the error body carried one.
+                // The lenient parser tolerates a newer server's unrecognized elements/codes.
+                IBaseOperationOutcome outcome = null;
+                try {
+                    IBaseResource errorResource = parser.parseResource(responseBody);
+                    if (errorResource instanceof IBaseOperationOutcome) {
+                        outcome = (IBaseOperationOutcome) errorResource;
+                    }
+                } catch (RuntimeException ignored) {
+                    // non-FHIR error body; leave outcome null
+                }
+                throw new SdcOperationException(relativePath, status, outcome,
+                        "SDC operation '" + relativePath + "' failed with status " + status + ".");
+            }
+
+            final IBaseResource parsed;
+            try {
+                parsed = parser.parseResource(responseBody);
+            } catch (RuntimeException ex) {
+                throw new SdcOperationException(relativePath, status, null,
+                        "SDC operation '" + relativePath + "' returned a body that could not be parsed as FHIR: "
+                                + ex.getMessage());
+            }
+
+            if (returnType.isInstance(parsed)) {
+                return returnType.cast(parsed);
+            }
+            // Wrong resource type on a success status. Carry the OperationOutcome (if that's what came
+            // back) on the exception so the caller can inspect its diagnostics.
+            IBaseOperationOutcome asOutcome = parsed instanceof IBaseOperationOutcome
+                    ? (IBaseOperationOutcome) parsed : null;
+            throw new SdcOperationException(relativePath, status, asOutcome,
+                    "SDC operation '" + relativePath + "' returned '" + parsed.getClass().getSimpleName()
+                            + "', expected '" + returnType.getSimpleName() + "'.");
+        } catch (IOException ex) {
+            throw new SdcOperationException(relativePath, 0, null,
+                    "SDC operation '" + relativePath + "' failed: " + ex.getMessage());
+        }
+    }
+
+    /** Closes the internally-created HttpClient; a no-op when one was injected. */
+    @Override
+    public void close() throws IOException {
+        if (ownsClient) httpClient.close();
+    }
+}

--- a/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcClientBase.java
+++ b/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcClientBase.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
@@ -46,6 +47,12 @@ public abstract class SdcClientBase<
         implements Closeable {
 
     private static final String FHIR_JSON = "application/fhir+json";
+
+    // Finite timeouts for the internally-owned client. Apache's HttpClients.createDefault() applies
+    // none (infinite), which would hang a caller — possibly a host UI thread — against a stalled
+    // server. Callers who inject their own client keep full control.
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+    private static final int SOCKET_TIMEOUT_MS = 60_000;
 
     private final String baseUrl;
     private final FhirContext fhirContext;
@@ -86,7 +93,12 @@ public abstract class SdcClientBase<
         this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
 
         if (httpClient == null) {
-            this.httpClient = HttpClients.createDefault();
+            RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectTimeout(CONNECT_TIMEOUT_MS)
+                    .setConnectionRequestTimeout(CONNECT_TIMEOUT_MS)
+                    .setSocketTimeout(SOCKET_TIMEOUT_MS)
+                    .build();
+            this.httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
             this.ownsClient = true;
         } else {
             this.httpClient = httpClient;
@@ -151,7 +163,7 @@ public abstract class SdcClientBase<
             } catch (RuntimeException ex) {
                 throw new SdcOperationException(relativePath, status, null,
                         "SDC operation '" + relativePath + "' returned a body that could not be parsed as FHIR: "
-                                + ex.getMessage());
+                                + ex.getMessage(), ex);
             }
 
             if (returnType.isInstance(parsed)) {
@@ -166,7 +178,7 @@ public abstract class SdcClientBase<
                             + "', expected '" + returnType.getSimpleName() + "'.");
         } catch (IOException ex) {
             throw new SdcOperationException(relativePath, 0, null,
-                    "SDC operation '" + relativePath + "' failed: " + ex.getMessage());
+                    "SDC operation '" + relativePath + "' failed: " + ex.getMessage(), ex);
         }
     }
 

--- a/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcClientBase.java
+++ b/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcClientBase.java
@@ -19,6 +19,8 @@ import org.apache.http.util.EntityUtils;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -45,6 +47,8 @@ public abstract class SdcClientBase<
         TOperationOutcome extends IBaseOperationOutcome,
         TBundle extends IBaseBundle>
         implements Closeable {
+
+    private static final Logger log = LoggerFactory.getLogger(SdcClientBase.class);
 
     private static final String FHIR_JSON = "application/fhir+json";
 
@@ -136,8 +140,10 @@ public abstract class SdcClientBase<
         request.setEntity(new StringEntity(json, ContentType.create(FHIR_JSON, StandardCharsets.UTF_8)));
         request.setHeader("Accept", FHIR_JSON);
 
+        log.debug("SDC POST {}", request.getURI());
         try (CloseableHttpResponse response = httpClient.execute(request)) {
             final int status = response.getStatusLine().getStatusCode();
+            log.debug("SDC {} -> {}", relativePath, status);
             final HttpEntity entity = response.getEntity();
             final String responseBody = entity == null ? "" : EntityUtils.toString(entity, StandardCharsets.UTF_8);
 

--- a/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcOperationException.java
+++ b/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcOperationException.java
@@ -20,7 +20,11 @@ public class SdcOperationException extends RuntimeException {
     private final transient IBaseOperationOutcome outcome;
 
     public SdcOperationException(String operation, int statusCode, IBaseOperationOutcome outcome, String message) {
-        super(message);
+        this(operation, statusCode, outcome, message, null);
+    }
+
+    public SdcOperationException(String operation, int statusCode, IBaseOperationOutcome outcome, String message, Throwable cause) {
+        super(message, cause);
         this.operation = operation;
         this.statusCode = statusCode;
         this.outcome = outcome;

--- a/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcOperationException.java
+++ b/sdc-client-core/src/main/java/health/tiro/sdc/client/SdcOperationException.java
@@ -1,0 +1,43 @@
+package health.tiro.sdc.client;
+
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+
+/**
+ * Thrown when an SDC server operation fails at the transport/server level (a non-success HTTP
+ * status). Carries the operation, the HTTP status, and — when the server returned one — the parsed
+ * {@link IBaseOperationOutcome} describing the failure.
+ *
+ * <p>A {@code $validate} call that merely reports validation issues is NOT an error: it returns a
+ * normal 200 with an {@code OperationOutcome}, which the client returns directly. This exception is
+ * reserved for actual operation failures (4xx/5xx, unreadable bodies, etc.).
+ */
+public class SdcOperationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String operation;
+    private final int statusCode;
+    private final transient IBaseOperationOutcome outcome;
+
+    public SdcOperationException(String operation, int statusCode, IBaseOperationOutcome outcome, String message) {
+        super(message);
+        this.operation = operation;
+        this.statusCode = statusCode;
+        this.outcome = outcome;
+    }
+
+    /** The operation that failed, e.g. {@code QuestionnaireResponse/$validate}. */
+    public String getOperation() {
+        return operation;
+    }
+
+    /** The HTTP status code returned by the SDC server. */
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    /** The server's OperationOutcome, if the error body contained one; otherwise {@code null}. */
+    public IBaseOperationOutcome getOutcome() {
+        return outcome;
+    }
+}

--- a/sdc-client-r5/pom.xml
+++ b/sdc-client-r5/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>health.tiro</groupId>
+        <artifactId>smart-web-messaging-parent</artifactId>
+        <version>2.0.0</version>
+    </parent>
+
+    <artifactId>sdc-client-r5</artifactId>
+    <packaging>jar</packaging>
+
+    <name>SDC Client (FHIR R5)</name>
+    <description>FHIR R5 closed binding of the SDC client ($validate, $extract).</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>health.tiro</groupId>
+            <artifactId>sdc-client-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-structures-r5</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/sdc-client-r5/src/main/java/health/tiro/sdc/client/r5/SdcClient.java
+++ b/sdc-client-r5/src/main/java/health/tiro/sdc/client/r5/SdcClient.java
@@ -1,0 +1,37 @@
+package health.tiro.sdc.client.r5;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.OperationOutcome;
+import org.hl7.fhir.r5.model.QuestionnaireResponse;
+
+import ca.uhn.fhir.context.FhirContext;
+import health.tiro.sdc.client.SdcClientBase;
+
+/**
+ * FHIR R5 SDC client. Wraps the stateless SDC server operations
+ * {@code QuestionnaireResponse/$validate} and {@code QuestionnaireResponse/$extract}.
+ *
+ * <p>These operations are R5-only on the SDC server. Construct with the server's FHIR base
+ * (e.g. {@code https://host/fhir/r5}); optionally inject a pre-configured
+ * {@link CloseableHttpClient} for custom TLS/proxy.
+ *
+ * <p>There is intentionally no default base URL: it is the same concept as the form viewer's
+ * {@code FormFillerConfig.sdcEndpointAddress}, so a host that embeds the form and also calls this
+ * client should configure the SDC address once and pass that single value to both, rather than
+ * risk the two pointing at different servers.
+ */
+public final class SdcClient extends SdcClientBase<QuestionnaireResponse, OperationOutcome, Bundle> {
+
+    // forR5Cached() is a shared, thread-safe context; the base builds a fresh lenient parser from it
+    // per request and never mutates it (so other code using forR5Cached() is unaffected).
+    private static final FhirContext CTX = FhirContext.forR5Cached();
+
+    public SdcClient(String baseUrl) {
+        this(baseUrl, null);
+    }
+
+    public SdcClient(String baseUrl, CloseableHttpClient httpClient) {
+        super(baseUrl, CTX, OperationOutcome.class, Bundle.class, httpClient);
+    }
+}

--- a/sdc-client-r5/src/test/java/health/tiro/sdc/client/r5/SdcClientTest.java
+++ b/sdc-client-r5/src/test/java/health/tiro/sdc/client/r5/SdcClientTest.java
@@ -1,0 +1,170 @@
+package health.tiro.sdc.client.r5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.OperationOutcome;
+import org.hl7.fhir.r5.model.QuestionnaireResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.LenientErrorHandler;
+import health.tiro.sdc.client.SdcOperationException;
+
+class SdcClientTest {
+
+    private static final FhirContext CTX = FhirContext.forR5Cached();
+
+    private HttpServer server;
+    private RecordingHandler handler;
+    private SdcClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        handler = new RecordingHandler();
+        server.createContext("/", handler);
+        server.start();
+        int port = server.getAddress().getPort();
+        client = new SdcClient("http://127.0.0.1:" + port + "/fhir/r5");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) client.close();
+        if (server != null) server.stop(0);
+    }
+
+    private static QuestionnaireResponse sampleResponse() {
+        QuestionnaireResponse qr = new QuestionnaireResponse();
+        qr.setStatus(QuestionnaireResponse.QuestionnaireResponseStatus.COMPLETED);
+        qr.setQuestionnaire("http://example.org/Questionnaire/intake|1.0.0");
+        return qr;
+    }
+
+    @Test
+    void validate_postsBareQuestionnaireResponse_andReturnsOutcome() {
+        handler.respond(200, "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"information\",\"code\":\"informational\",\"diagnostics\":\"valid\"}]}");
+
+        OperationOutcome outcome = client.validate(sampleResponse());
+
+        assertNotNull(outcome);
+        assertEquals(OperationOutcome.IssueSeverity.INFORMATION, outcome.getIssueFirstRep().getSeverity());
+
+        assertEquals("POST", handler.method);
+        assertEquals("/fhir/r5/QuestionnaireResponse/$validate", handler.path);
+        assertTrue(handler.contentType.startsWith("application/fhir+json"));
+
+        // The body is a BARE QuestionnaireResponse — not a Parameters envelope (guards the design decision).
+        IBaseResource sentBody = CTX.newJsonParser().setParserErrorHandler(new LenientErrorHandler())
+                .parseResource(handler.requestBody);
+        assertTrue(sentBody instanceof QuestionnaireResponse, "expected a bare QuestionnaireResponse body");
+    }
+
+    @Test
+    void validate_withErrorIssues_returnsOutcomeWithoutThrowing() {
+        handler.respond(200, "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\"required\",\"diagnostics\":\"missing answer\"}]}");
+
+        OperationOutcome outcome = client.validate(sampleResponse());
+
+        // A validation failure is data, not an exception.
+        assertEquals(OperationOutcome.IssueSeverity.ERROR, outcome.getIssueFirstRep().getSeverity());
+    }
+
+    @Test
+    void extract_postsToExtract_andReturnsBundle() {
+        handler.respond(200, "{\"resourceType\":\"Bundle\",\"type\":\"transaction\"}");
+
+        Bundle bundle = client.extract(sampleResponse());
+
+        assertNotNull(bundle);
+        assertEquals(Bundle.BundleType.TRANSACTION, bundle.getType());
+        assertEquals("/fhir/r5/QuestionnaireResponse/$extract", handler.path);
+    }
+
+    @Test
+    void nonSuccessStatus_throwsSdcOperationException_carryingOutcome() {
+        handler.respond(400, "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"fatal\",\"code\":\"processing\",\"diagnostics\":\"boom\"}]}");
+
+        SdcOperationException ex = assertThrows(SdcOperationException.class, () -> client.validate(sampleResponse()));
+
+        assertEquals(400, ex.getStatusCode());
+        assertNotNull(ex.getOutcome());
+        assertEquals(OperationOutcome.IssueSeverity.FATAL,
+                ((OperationOutcome) ex.getOutcome()).getIssueFirstRep().getSeverity());
+    }
+
+    @Test
+    void recoverableBody_isParsed_notThrown() {
+        // A 200 carrying an element this HAPI version doesn't recognize (as a newer server would emit).
+        // The lenient parser should tolerate it rather than fail.
+        handler.respond(200, "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"information\",\"code\":\"informational\"}],\"madeUpFutureElement\":\"x\"}");
+
+        OperationOutcome outcome = client.validate(sampleResponse());
+
+        assertEquals(OperationOutcome.IssueSeverity.INFORMATION, outcome.getIssueFirstRep().getSeverity());
+    }
+
+    @Test
+    void constructor_rejectsBaseUrlWithQuery() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new SdcClient("https://sdc.test.local/fhir/r5?key=abc"));
+    }
+
+    /** Captures the inbound request and serves a canned FHIR JSON response. */
+    private static final class RecordingHandler implements HttpHandler {
+        private int responseStatus = 200;
+        private String responseBody = "";
+        String method;
+        String path;
+        String contentType;
+        String requestBody;
+
+        void respond(int status, String fhirJson) {
+            this.responseStatus = status;
+            this.responseBody = fhirJson;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            method = exchange.getRequestMethod();
+            path = exchange.getRequestURI().toString();
+            contentType = exchange.getRequestHeaders().getFirst("Content-Type");
+            requestBody = readAll(exchange.getRequestBody());
+
+            byte[] out = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/fhir+json");
+            exchange.sendResponseHeaders(responseStatus, out.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(out);
+            }
+        }
+
+        private static String readAll(InputStream in) throws IOException {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                bos.write(buf, 0, n);
+            }
+            return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
Closes #19. Java sibling of Tiro-health/net-integration-harness#24 (PR #30).

## Summary

A thin, strongly-typed client over the stateless SDC server FHIR operations, so Java hosts call them directly instead of hand-building request bodies and parsing raw responses. (`$populate` is deferred to #20, pending atticus-backend#3164.)

## Structure — generic core + R5 binding (R4-ready)

Mirrors the repo's `smart-web-messaging-core/-r5` split and the .NET sibling, so a future R4 SDC server is **one new `sdc-client-r4` binding** with no core change:

- **`sdc-client-core`** — `SdcClientBase<TQuestionnaireResponse, TOperationOutcome, TBundle>` over the HL7 `IBase*` interfaces, with `validate → OperationOutcome` and `extract → Bundle`, plus `SdcOperationException`.
- **`sdc-client-r5`** — `SdcClient` closed binding (`FhirContext.forR5Cached()`).

## Key implementation decisions (carried from the .NET sibling)

- Both endpoints take a **bare `QuestionnaireResponse`** body (verified against the Atticus `sdc_server` and staging), **not** a `Parameters` envelope — so HAPI's `operation()`/`validate()` helpers (which wrap in `Parameters`) are **not** used. The core POSTs the resource directly via **Apache HttpClient** using a HAPI `IParser` (Java 8 rules out `java.net.http.HttpClient`); the client is injectable for TLS/proxy.
- A validation failure is returned as `OperationOutcome` issues, **not** thrown; only non-2xx throws `SdcOperationException` carrying the status + any server outcome.
- **No default base URL** — it's the same concept as the viewer's `FormFillerConfig.sdcEndpointAddress`, so a default could silently diverge; a base with a query/fragment is rejected.
- **Lenient parsing** via a per-call parser with `LenientErrorHandler` (never mutating the shared cached `FhirContext`), so a newer server's unrecognized elements/codes don't fail.

| Operation | Path (rel. to `…/fhir/r5`) | Body | Result |
|---|---|---|---|
| `$validate` | `QuestionnaireResponse/$validate` | bare `QuestionnaireResponse` | `OperationOutcome` |
| `$extract` | `QuestionnaireResponse/$extract` | bare `QuestionnaireResponse` | transaction `Bundle` |

## Tests

JUnit 5 against the **JDK's built-in `HttpServer`** (MockWebServer pulls okhttp 4.x, which conflicts with the okhttp 3.8.1 already on HAPI's classpath — the zero-dep `com.sun.net.httpserver` avoids the version war). Cases: bare-QR POST + path + content-type guard, validation-as-data, extract `Bundle`, non-2xx → `SdcOperationException`, lenient unknown-element, query-base rejected. **6/6 pass**; messaging modules unaffected (23+23).

## Incidental fix

Aligned `jackson-core` to the managed `${jackson.version}` (2.15.3). It was resolving to 2.13.1 transitively while `jackson-databind` was forced to 2.15.3 — a latent mismatch the SDC client's HAPI parsing surfaced (`NoClassDefFoundError: StreamConstraintsException`).

## Notes
- `$populate` → #20 (blocked on atticus-backend#3164). `$generate-narrative` — trivial later add. `$extract`'s `dataEndpoint`/`Accept-Language` — omitted v1.
- Nightly staging contract test tracked in #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)